### PR TITLE
MCP efficiency improvements - expose search_term argument on entities.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0]
+
+### Changed
+
+- **Performance Improvements**:
+  - Updated default pagination limits from 50 to 20 for `listEntities()`, `listInitiatives()`, `getInitiativeDetails()`, and `listScorecards()` for better performance/reduced payload size
+  - Added `search_term` parameter to `listEntities()` tool to enable efficient entity search and discovery
+  - Updated `reviewTasks` prompt to encourage use of the new search functionality
+
 ## [1.2.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dx-mcp-server"
-version = "1.2.0"
+version = "1.3.0"
 description = "Use natural language to write and execute queries on your organizational data in DX Data Cloud"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dx_mcp_server/prompts/scorecard_prompts.py
+++ b/src/dx_mcp_server/prompts/scorecard_prompts.py
@@ -16,13 +16,13 @@ def reviewTasks() -> str:
 - If you cannot fully resolve with available tools/code changes, explain what's missing and propose the next best actions.
 
 ### Tools you'll likely need to use (preferred order)
-- listEntities(): find the right entity if the identifier is unclear.
+- listEntities(search_term=...): find the right entity if the identifier is unclear, use the search_term parameter to find the right entity.
 - getEntityDetails(identifier=...): primary source for the entity's **tasks** (including latest status/results) and **scorecards** including **check definitions/criteria**.
 
 ### Step 1 — Identify the entity
 - If `entity_identifier` is provided: use it.
 - Otherwise infer from context (repo name/cwd if available). If still uncertain:
-  - Call listEntities() and select the best match. If ambiguous, ask 1 question ("Which entity do you mean: A or B?").
+  - Call listEntities(search_term=...) and select the best match. If ambiguous, ask 1 question ("Which entity do you mean: A or B?").
 
 ### Step 2 — Load tasks and discover the target check(s)
 - Call getEntityDetails(identifier=...).

--- a/src/dx_mcp_server/tools/entity_tools.py
+++ b/src/dx_mcp_server/tools/entity_tools.py
@@ -9,28 +9,32 @@ WEB_API_TOKEN = environ.get("WEB_API_TOKEN", "")
 
 @mcp.tool()
 def listEntities(
-    cursor: str = None,
-    limit: int = 50,
+    search_term: str = None,
     type: str = None,
+    cursor: str = None,
+    limit: int = 20,
 ) -> dict:
     """
     List entities from the DX software catalog.
 
     Args:
+        search_term (str, optional): Search term to filter by.
+        type (str, optional): Filter entities by type (e.g., 'service', 'team', etc.).
         cursor (str, optional): Cursor for pagination. Get from response_metadata.next_cursor in prior requests.
         limit (int, optional): Number of entities per page - if present, must be between 1 and 50.
-        type (str, optional): Filter entities by type (e.g., 'service', 'team', etc.).
     """
     if not WEB_API_TOKEN:
         return {"error": "WEB_API_TOKEN environment variable is not set"}
 
     params = {}
+    if search_term:
+        params["search_term"] = search_term
+    if type:
+        params["type"] = type
     if cursor:
         params["cursor"] = cursor
     if limit:
         params["limit"] = limit
-    if type:
-        params["type"] = type
 
     url = f"{DX_API_HOST}/entities.list"
     headers = {

--- a/src/dx_mcp_server/tools/scorecard_tools.py
+++ b/src/dx_mcp_server/tools/scorecard_tools.py
@@ -10,7 +10,7 @@ WEB_API_TOKEN = environ.get("WEB_API_TOKEN", "")
 @mcp.tool()
 def listInitiatives(
     cursor: str = None,
-    limit: int = 50,
+    limit: int = 20,
     published: bool = None,
     priority: int = None,
     tags: str = None,
@@ -68,7 +68,7 @@ def listInitiatives(
 def getInitiativeDetails(
     id: str,
     entity_type_identifiers: str = None,
-    limit: int = 50,
+    limit: int = 20,
     cursor: str = None,
 ) -> dict:
     """
@@ -146,7 +146,7 @@ def getInitiativeDetails(
 
 
 @mcp.tool()
-def listScorecards(cursor: str = None, limit: int = 50) -> dict:
+def listScorecards(cursor: str = None, limit: int = 20) -> dict:
     """
     List all active scorecards.
     Args:


### PR DESCRIPTION
## Context
We want to improve the efficiency/speed of our MCP tools - this PR makes 2 improvements:
- Ratchets down the default limits on list tools so that we send back smaller payloads for ai to iteratively process
- Exposes the new `search_term` arg on the entities.list web api endpoint so the ai has a quicker shot method to narrow down the relevant entity.
