### PR TITLE
Remove incorrect claude desktop config from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,23 +65,6 @@ Add this configuration to your MCP settings (**Cursor > Settings > Cursor Settin
 }
 ```
 
-### Claude for Desktop
-
-Add this configuration via **Claude > Settings > Developer > Edit Config**:
-
-```json
-{
-  "mcpServers": {
-    "dx-mcp": {
-      "url": "https://ai.getdx.com/mcp",
-      "headers": {
-        "Authorization": "Bearer [YOUR_WEB_API_TOKEN]"
-      }
-    }
-  }
-}
-```
-
 ---
 
 ## Option 2: Local Installation


### PR DESCRIPTION
Remove incorrect claude desktop config - claude desktop doesn't currently allow using headers for authentication
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>You don't have access to Rovo Dev Standard</strong>
Ask your organization admin to add you to Rovo Dev Standard.
[More about code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

